### PR TITLE
缺失回车换行符会严重影响账单的解析，添加因格式解析而丢弃的'\n'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>utf-8</project.reporting.outputEncoding>
+        		<java.version>1.8</java.version>
     </properties>
 
     <dependencies>
@@ -100,6 +101,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
                 </plugins>
             </build>
         </profile>

--- a/src/main/java/com/github/wxpay/sdk/WXPay.java
+++ b/src/main/java/com/github/wxpay/sdk/WXPay.java
@@ -130,7 +130,7 @@ public class WXPay {
         final StringBuffer stringBuffer = new StringBuffer();
         String line = null;
         while ((line = bufferedReader.readLine()) != null) {
-            stringBuffer.append(line);
+            stringBuffer.append(line).append("\n");
         }
         String resp = stringBuffer.toString();
         if (stringBuffer!=null) {


### PR DESCRIPTION
缺失回车换行符会严重影响账单的解析，建议添加因格式解析而丢弃的'\n'